### PR TITLE
Added https:// to bootstrap cdn addresses

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -3,10 +3,10 @@
     <head>
         <title>Code@LTH{% if page.title %} - {{ page.title }}{% endif %}</title>
 
-        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-        <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
         <link href="/css/syntax.css" rel="stylesheet">
         <link href="/css/about.css" rel="stylesheet">


### PR DESCRIPTION
The CSS didn't load for me on Firefox 53.0.3 (64-bit) on Mac, even when I had all plugins disabled.

This was the output from the console:

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).  (unknown)
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing). (unknown)
None of the “sha384” hashes in the integrity attribute match the content of the subresource.
```

When adding `https://` to the CDN addresses seems to fix it!