### PR TITLE
Added Ludum Dare pages

### DIFF
--- a/_data/pages.yml
+++ b/_data/pages.yml
@@ -13,6 +13,11 @@
 - name: Join
   url: /join
   id: join
+
 - name: Hash Code
   url: /hashcode
   id: hashcode
+
+- name: Ludum Dare
+  url: /ludumdare
+  id: ludumdare

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -2,5 +2,5 @@ Code@LTH is a coding community at
 <a href="https://en.wikipedia.org/wiki/Faculty_of_Engineering_(LTH),_Lund_University">The Faculty of Engineering</a>, <a href="https://en.wikipedia.org/wiki/Lund_University">Lund University</a>
 created to motivate and inspire people to code recreationally.
 
-We arrange a diverse range of events related to programming, including things like lectures, programming contests (including <a href="https://hashcode.withgoogle.com/">Google Hashcode</a> and <a href="http://ludumdare.com">Ludum Dare</a>), hackathons, presentations about members projects and more.
+We arrange a diverse range of events related to programming, including things like lectures, programming contests (including <a href="https://hashcode.withgoogle.com/">Google Hashcode</a> and <a href="https://ldjam.com">Ludum Dare</a>), hackathons, presentations about members projects and more.
 The events are open to programmers of all skill levels and generally anybody who wants to join in on the fun!

--- a/_posts/2019-03-31-ludumdare.md
+++ b/_posts/2019-03-31-ludumdare.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title:  "Ludum Dare 44"
+date:   2019-03-31 21:42 +0200
+---
+
+Ludum Dare is an international game jam organized independently and Code@LTH are holding a local hub where you get up to 72 hours to work on a game based on a theme (revealed right at the start), alone or with friends. We encourage people who make art/music/other to also come, all types of creative can go into a game! 
+
+In the weeks before the competition we will have a few events to make you ready for the challenge. These events are listed below, as well as the main event iself.
+
+## Events
+
+### April 11: [Intro to the Godot game engine + workshop](https://www.facebook.com/events/315211862497848/)
+
+Making computer games has never been easier! With the open sorce, multi platform game engine Godot you can make a game in hours that would normally take days, weeks or even months!
+
+The game engine is lightweight, yet powerful. It has a rich feature set and is easy to use. Have you always wanted to make a game? This is the perfect opportunity to make that dream come true!
+
+We will first have a brief introduction to the game engine, and then move to another room to try it out. We recommend you to bring your own computer.
+
+The game engine can be found [here](https://godotengine.org/), along with a lot of useful resources, like documentation and examples.
+
+We can strongly recommend [this tutorial](https://www.youtube.com/watch?v=wETY5_9kFtA&list=PL9FzW-m48fn2jlBu_0DRh7PvAt-GULEmd&index=1), in which a simple platformer is made in only 7 episodes.
+
+### April 25: [How to Ludum Dare](https://www.facebook.com/events/428336241042798/)
+
+With only two days until Ludum Dare, it's good to know something about how to participate.
+
+Some topics that might be covered:
+- Compo vs Jam
+- The rules
+- How to submit your game
+- Exporting the game, using the Godot engine as an example
+- The voting system
+- General tips and tricks.
+- Q&A
+
+### April 27-28: [Ludum Dare](https://www.facebook.com/events/507264130096976/)
+
+Your game making skills are about to be put to the test!
+Can you make a game from scratch in only 48 hours?
+Ludum Dare is a game jam where every participant gets 48 hours to make a game on a given theme.
+
+After the competition is over all the contestants can vote on the other submissions. In the end there might be one game winning as the "Funniest game", and another for "Best graphics" and so on.
+
+We recommend that you use some kind of tool or game engine, e.g. Godot which is very easy to use.
+
+We also really recommend reading (or at least skimming) the Ludum Dare [about](https://ldjam.com/about) and/or [rules](https://ldjam.com/events/ludum-dare/rules). But to save you some reading: you don’t need to sign up before LD starts but you will need to submit your game before it ends (assuming you want to submit it at all).

--- a/ludumdare.md
+++ b/ludumdare.md
@@ -1,0 +1,19 @@
+---
+layout: panel-with-sidebar
+title: Ludum Dare
+id: ludumdare
+---
+
+# Ludum Dare
+
+Ludum Dare is an international game jam organized independently and Code@LTH are holding a local hub where you get up to 72 hours to work on a game based on a theme (revealed right at the start), alone or with friends. We encourage people who make art/music/other to also come, all types of creative can go into a game! 
+
+More information about the upcoming **Ludum Dare 44** can be found on [this blog post](/blog/2019/03/31/ludumdare).
+
+## Events
+
+### April 11: [Intro to the Godot game engine + workshop](https://www.facebook.com/events/315211862497848/)
+
+### April 25: [How to Ludum Dare](https://www.facebook.com/events/428336241042798/)
+
+### April 27-28: [Ludum Dare](https://www.facebook.com/events/507264130096976/)


### PR DESCRIPTION
These pages contain information for the upcoming Ludum Dare-related events. It's a blog post and a tab, where the tab can be reused for the next LD.
Also fixed a broken link.